### PR TITLE
解决react-nativev68 ios debug 报错的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### v 2.4.9
+- ios 解决react-nativev68 ios debug 报错的问题
 ### v 2.4.8
 - android 更新到 2.7.2，iOS sdk更新到2.7.1 。
 

--- a/ios/RCTJVerificationModule/RCTJVerificationModule.m
+++ b/ios/RCTJVerificationModule/RCTJVerificationModule.m
@@ -223,7 +223,7 @@ RCT_EXPORT_METHOD(customUIWithConfig: (NSDictionary *)configParams viewParams: (
                     rctView = [[RCTRootView alloc] initWithBridge:self.bridge moduleName:viewParams[i][CUSTOM_VIEW_NAME] initialProperties:nil];
                 }
                 else {
-                    NSURL *jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+                    NSURL *jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
                     rctView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation moduleName:viewParams[i][CUSTOM_VIEW_NAME] initialProperties:nil launchOptions:nil];
                 }
                 NSArray *point = viewParams[i][CUSTOM_VIEW_POINT];

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "license": "ISC",
   "author": "wicked.tc130",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/jpush/jverification-react-native"


### PR DESCRIPTION
产生问题的链接 [#33451](https://github.com/facebook/react-native/issues/33451)

![image](https://user-images.githubusercontent.com/18526704/173824651-896d0346-6de6-4225-991c-bb08b3750eff.png)
